### PR TITLE
fix(2fa): Return correct error for bad TOTP code in 2FA setup

### DIFF
--- a/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
+++ b/packages/better-auth/src/plugins/two-factor/verify-two-factor.ts
@@ -9,6 +9,15 @@ import { TWO_FACTOR_ERROR_CODES } from "./error-code";
 
 export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 	const session = await getSessionFromCtx(ctx);
+
+	const handleInvalid = async (
+		errorKey: keyof typeof TWO_FACTOR_ERROR_CODES,
+	) => {
+		throw new APIError("UNAUTHORIZED", {
+			message: TWO_FACTOR_ERROR_CODES[errorKey],
+		});
+	};
+
 	if (!session) {
 		const cookieName = ctx.context.createAuthCookie(TWO_FACTOR_COOKIE_NAME);
 		const twoFactorCookie = await ctx.getSignedCookie(
@@ -98,11 +107,7 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 					},
 				});
 			},
-			invalid: async (errorKey: keyof typeof TWO_FACTOR_ERROR_CODES) => {
-				throw new APIError("UNAUTHORIZED", {
-					message: TWO_FACTOR_ERROR_CODES[errorKey],
-				});
-			},
+			invalid: handleInvalid,
 			session: {
 				session: null,
 				user,
@@ -125,11 +130,7 @@ export async function verifyTwoFactor(ctx: GenericEndpointContext) {
 				},
 			});
 		},
-		invalid: async () => {
-			throw new APIError("UNAUTHORIZED", {
-				message: TWO_FACTOR_ERROR_CODES.INVALID_TWO_FACTOR_COOKIE,
-			});
-		},
+		invalid: handleInvalid,
 		session,
 		key: `${session.user.id}!${session.session.id}`,
 	};


### PR DESCRIPTION
When a logged-in user was setting up 2FA (TOTP) and submitted an incorrect code, they would receive a misleading `INVALID_TWO_FACTOR_COOKIE` error. This happened because the `verifyTwoFactor` helper, in cases where a session already existed, was hardcoding this error in its `invalid` handler.

This change modifies the `invalid` handler in `verifyTwoFactor` (for the "session exists" path) to accept and use the `errorKey` provided by the calling function. This allows the `verifyTOTP` endpoint handler to correctly signal an `INVALID_CODE` (or similar specific error) when a user enters the wrong TOTP.

As a small improvement, the `invalid` handler logic within `verifyTwoFactor` has also been refactored into a shared function to reduce duplication.

Closes #2631.